### PR TITLE
Use django-admin instead of django-admin.py

### DIFF
--- a/i18n/dummy.py
+++ b/i18n/dummy.py
@@ -12,7 +12,7 @@ localized for. So we are using a well-known language (default='eo').
 Django languages are listed in django.conf.global_settings.LANGUAGES
 
 po files can be generated with this:
-django-admin.py makemessages --all --extension html -l en
+django-admin makemessages --all --extension html -l en
 
 Usage:
 

--- a/i18n/extract.py
+++ b/i18n/extract.py
@@ -10,7 +10,7 @@ and produces three human-readable files:
    conf/locale/en/LC_MESSAGES/mako.po
 
 This task will clobber any existing django.po file.
-This is because django-admin.py makemessages hardcodes this filename
+This is because django-admin makemessages hardcodes this filename
 and it cannot be overridden.
 
 """
@@ -118,7 +118,7 @@ class Extract(Runner):
 
             execute(babel_underscore_cmd, working_directory=configuration.root_dir, stderr=stderr)
 
-        makemessages = f"django-admin.py makemessages -l en -v{args.verbose}"
+        makemessages = f"django-admin makemessages -l en -v{args.verbose}"
         ignores = " ".join(f'--ignore="{d}/*"' for d in configuration.ignore_dirs)
         if ignores:
             makemessages += " " + ignores
@@ -185,7 +185,7 @@ def fix_header(pofile):
     Replace default headers with edX headers
     """
 
-    # By default, django-admin.py makemessages creates this header:
+    # By default, django-admin makemessages creates this header:
     #
     #   SOME DESCRIPTIVE TITLE.
     #   Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
@@ -220,7 +220,7 @@ def fix_metadata(pofile):
     Replace default metadata with edX metadata
     """
 
-    # By default, django-admin.py makemessages creates this metadata:
+    # By default, django-admin makemessages creates this metadata:
     #
     #   {u'PO-Revision-Date': u'YEAR-MO-DA HO:MI+ZONE',
     #   u'Language': u'',

--- a/i18n/generate.py
+++ b/i18n/generate.py
@@ -184,7 +184,7 @@ class Generate(Runner):
         if configuration.source_locale not in langs:
             merge_files(configuration, configuration.source_locale, fail_if_missing=args.strict)
 
-        compile_cmd = f'django-admin.py compilemessages -v{args.verbose}'
+        compile_cmd = f'django-admin compilemessages -v{args.verbose}'
         if args.verbose:
             stderr = None
         else:


### PR DESCRIPTION
Django 3.0 deprecated the `django-admin.py` command and Django 4.0 removed it in favor of `django-admin`.

https://docs.djangoproject.com/en/4.1/releases/4.0/