### PR TITLE
Always remove POT-Creation-Date metadata

### DIFF
--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '0.9.2'
+__version__ = '1.0.0'
 
 
 class Runner:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 import os
-from unittest import skip
 
 import polib
 from path import Path
@@ -9,11 +8,7 @@ from i18n import extract, config
 
 from . import I18nToolTestCase, MOCK_DJANGO_APP_DIR
 
-# Make sure setup runs only once
-SETUP_HAS_RUN = False
 
-
-@skip('Tests need to be updated to new repo')
 class TestExtract(I18nToolTestCase):
     """
     Tests functionality of i18n/extract.py
@@ -21,8 +16,6 @@ class TestExtract(I18nToolTestCase):
     generated_files = ('django-partial.po', 'djangojs-partial.po', 'mako.po')
 
     def setUp(self):
-        global SETUP_HAS_RUN
-
         super().setUp()
 
         # Subtract 1 second to help comparisons with file-modify time succeed,
@@ -38,10 +31,8 @@ class TestExtract(I18nToolTestCase):
         )
         self.configuration = config.Configuration(root_dir=MOCK_DJANGO_APP_DIR)
 
-        if not SETUP_HAS_RUN:
-            # Run extraction script. Warning, this takes 1 minute or more
-            extract.main(verbosity=0, config=self.configuration._filename, root_dir=MOCK_DJANGO_APP_DIR)
-            SETUP_HAS_RUN = True
+        # Run extraction script
+        extract.main(verbosity=0, config=self.configuration._filename, root_dir=MOCK_DJANGO_APP_DIR)
 
     def get_files(self):
         """

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -68,7 +68,9 @@ class TestExtract(I18nToolTestCase):
         self.assertFalse(extract.is_key_string(entry2.msgid))
 
     def test_headers(self):
-        """Verify all headers have been modified"""
+        """
+        Verify all headers have been modified
+        """
         for path in self.get_files():
             po = polib.pofile(path)
             header = po.header
@@ -78,10 +80,21 @@ class TestExtract(I18nToolTestCase):
             )
 
     def test_metadata(self):
-        """Verify all metadata has been modified"""
+        """
+        Verify all metadata has been modified
+        """
         for path in self.get_files():
             po = polib.pofile(path)
             metadata = po.metadata
             value = metadata['Report-Msgid-Bugs-To']
             expected = 'openedx-translation@googlegroups.com'
             self.assertEquals(expected, value)
+
+    def test_metadata_no_create_date(self):
+        """
+        Verify `POT-Creation-Date` metadata has been removed
+        """
+        for path in self.get_files():
+            po = polib.pofile(path)
+            metadata = po.metadata
+            self.assertIsNone(metadata.get('POT-Creation-Date'))


### PR DESCRIPTION
After multiple discussions, and as part of [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) project; the team decided to always remove `POT-Creation-Date` from translation extraction (from `extract` command). The reason is that this metadata is causing [openedx-translations](https://github.com/openedx/openedx-translations) repo to generate too many useless commits that differ only in Creation Date in related files (see example commits [here](https://github.com/openedx/openedx-translations/pull/287/files))

This PR will also activate tests for `extract` script that have been skipped a long time ago because it was part of `edx-platform`