### PR TITLE
feat: refactor extract command with its tests

### DIFF
--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,20 +1,41 @@
-from datetime import datetime, timedelta
 import os
+from datetime import datetime, timedelta
+from functools import wraps
 
 import polib
+from i18n import extract, config
 from path import Path
 
-from i18n import extract, config
-
 from . import I18nToolTestCase, MOCK_DJANGO_APP_DIR
+
+
+def perform_extract():
+    """
+    Decorator for test methods in TestExtract class.
+    """
+    def decorator(test_method):
+        """
+        The decorator itself
+        """
+        @wraps(test_method)
+        def wrapped(self):
+            """
+            The wrapper function
+            """
+            extract.main(
+                verbosity=0,
+                config=self.configuration._filename,
+                root_dir=MOCK_DJANGO_APP_DIR,
+            )
+            test_method(self)
+        return wrapped
+    return decorator
 
 
 class TestExtract(I18nToolTestCase):
     """
     Tests functionality of i18n/extract.py
     """
-    generated_files = ('django-partial.po', 'djangojs-partial.po', 'mako.po')
-
     def setUp(self):
         super().setUp()
 
@@ -31,8 +52,19 @@ class TestExtract(I18nToolTestCase):
         )
         self.configuration = config.Configuration(root_dir=MOCK_DJANGO_APP_DIR)
 
-        # Run extraction script
-        extract.main(verbosity=0, config=self.configuration._filename, root_dir=MOCK_DJANGO_APP_DIR)
+    @property
+    def django_po(self):
+        """
+        Returns the name of the generated django file
+        """
+        return 'django-partial.po'
+
+    @property
+    def djangojs_po(self):
+        """
+        Returns the name of the generated djangojs file
+        """
+        return 'djangojs-partial.po'
 
     def get_files(self):
         """
@@ -40,13 +72,16 @@ class TestExtract(I18nToolTestCase):
         Returns the fully expanded filenames for all extracted files
         Fails assertion if one of the files doesn't exist.
         """
-        for filename in self.generated_files:
+        generated_files = ('mako.po', self.django_po, self.djangojs_po,)
+
+        for filename in generated_files:
             path = Path.joinpath(self.configuration.source_messages_dir, filename)
             exists = Path.exists(path)
             self.assertTrue(exists, msg='Missing file: %s' % path)
-            if exists:
-                yield path
 
+            yield path
+
+    @perform_extract()
     def test_files(self):
         """
         Asserts that each auto-generated file has been modified since 'extract' was launched.
@@ -56,6 +91,7 @@ class TestExtract(I18nToolTestCase):
             self.assertTrue(datetime.fromtimestamp(os.path.getmtime(path)) > self.start_time,
                             msg='File not recently modified: %s' % path)
 
+    @perform_extract()
     def test_is_keystring(self):
         """
         Verifies is_keystring predicate
@@ -67,6 +103,7 @@ class TestExtract(I18nToolTestCase):
         self.assertTrue(extract.is_key_string(entry1.msgid))
         self.assertFalse(extract.is_key_string(entry2.msgid))
 
+    @perform_extract()
     def test_headers(self):
         """
         Verify all headers have been modified
@@ -79,6 +116,7 @@ class TestExtract(I18nToolTestCase):
                 msg='Missing header in %s:\n"%s"' % (path, header)
             )
 
+    @perform_extract()
     def test_metadata(self):
         """
         Verify all metadata has been modified
@@ -90,6 +128,7 @@ class TestExtract(I18nToolTestCase):
             expected = 'openedx-translation@googlegroups.com'
             self.assertEquals(expected, value)
 
+    @perform_extract()
     def test_metadata_no_create_date(self):
         """
         Verify `POT-Creation-Date` metadata has been removed


### PR DESCRIPTION
Refactor for more usability and readability. And to prepare tests to deal with options to be added to `extract` command in future pull-requests

* Get babel processing out of `run` method into a separate method named `babel_extract`
* Refactor `TestExtract` to avoid calling the mocked `extract` command unless it's needed. Doing that by creating a decorator named `perform_extract`

**Change log?**

**None**, just a code refactor