### PR TITLE
fix: Partial files are not added to cleaning process

### DIFF
--- a/i18n/extract.py
+++ b/i18n/extract.py
@@ -33,6 +33,14 @@ from i18n.segment import segment_pofiles
 EDX_MARKER = "edX translation file"
 LOG = logging.getLogger(__name__)
 DEVNULL = open(os.devnull, 'wb')    # pylint: disable=consider-using-with
+DJANGO_PO = 'django.po'
+DJANGO_PARTIAL_PO = 'django-partial.po'
+DJANGO_SAVED_PO = 'django-saved.po'
+DJANGOJS_PO = 'djangojs.po'
+DJANGOJS_PARTIAL_PO = 'djangojs-partial.po'
+DJANGOJS_SAVED_PO = 'djangojs-saved.po'
+MAKO_PO = 'mako.po'
+UNDERSCORE_PO = 'underscore.po'
 
 
 def file_exists(path_name):
@@ -79,8 +87,8 @@ class Extract(Runner):
 
         # The extraction process clobbers django.po and djangojs.po.
         # Save them so that it won't do that.
-        self.rename_source_file('django.po', 'django-saved.po')
-        self.rename_source_file('djangojs.po', 'djangojs-saved.po')
+        self.rename_source_file(DJANGO_PO, DJANGO_SAVED_PO)
+        self.rename_source_file(DJANGOJS_PO, DJANGOJS_SAVED_PO)
 
         # Extract strings from mako templates.
         verbosity_map = {
@@ -112,11 +120,11 @@ class Extract(Runner):
 
         # makemessages creates 'django.po'. This filename is hardcoded.
         # Rename it to django-partial.po to enable merging into django.po later.
-        self.rename_source_file('django.po', 'django-partial.po')
+        self.rename_source_file(DJANGO_PO, DJANGO_PARTIAL_PO)
 
         # makemessages creates 'djangojs.po'. This filename is hardcoded.
         # Rename it to djangojs-partial.po to enable merging into djangojs.po later.
-        self.rename_source_file('djangojs.po', 'djangojs-partial.po')
+        self.rename_source_file(DJANGOJS_PO, DJANGOJS_PARTIAL_PO)
 
         files_to_clean = set()
 
@@ -143,15 +151,15 @@ class Extract(Runner):
         files_to_clean.update(segmented_files)
 
         # Add partial files to the list of files to clean.
-        files_to_clean.update(('django_partial', 'djangojs_partial'))
+        files_to_clean.update((DJANGO_PARTIAL_PO, DJANGOJS_PARTIAL_PO))
 
         # Finish each file.
         for filename in files_to_clean:
             clean_pofile(self.source_msgs_dir.joinpath(filename))
 
         # Restore the saved .po files.
-        self.rename_source_file('django-saved.po', 'django.po')
-        self.rename_source_file('djangojs-saved.po', 'djangojs.po')
+        self.rename_source_file(DJANGO_SAVED_PO, DJANGO_PO)
+        self.rename_source_file(DJANGOJS_SAVED_PO, DJANGOJS_PO)
 
     def babel_extract(self, stderr, verbosity):
         """
@@ -174,7 +182,7 @@ class Extract(Runner):
             babel_mako_cmd = babel_cmd_template.format(
                 verbosity=verbosity,
                 config=babel_mako_cfg,
-                output=self.base(configuration.source_messages_dir, 'mako.po'),
+                output=self.base(configuration.source_messages_dir, MAKO_PO),
             )
 
             execute(babel_mako_cmd, working_directory=configuration.root_dir, stderr=stderr)
@@ -184,7 +192,7 @@ class Extract(Runner):
             babel_underscore_cmd = babel_cmd_template.format(
                 verbosity=verbosity,
                 config=babel_underscore_cfg,
-                output=self.base(configuration.source_messages_dir, 'underscore.po'),
+                output=self.base(configuration.source_messages_dir, UNDERSCORE_PO),
             )
 
             execute(babel_underscore_cmd, working_directory=configuration.root_dir, stderr=stderr)

--- a/i18n/generate.py
+++ b/i18n/generate.py
@@ -23,13 +23,14 @@ from polib import pofile
 
 from i18n import Runner
 from i18n.execute import execute
+from i18n.extract import DJANGO_PARTIAL_PO, DJANGO_PO
 
 LOG = logging.getLogger(__name__)
 DEVNULL = open(os.devnull, "wb")        # pylint: disable=consider-using-with
 DUPLICATE_ENTRY_PATTERN = re.compile('#-#-#-#-#.*#-#-#-#-#')
 
 
-def merge(configuration, locale, target='django.po', sources=('django-partial.po',), fail_if_missing=True):
+def merge(configuration, locale, target=DJANGO_PO, sources=(DJANGO_PARTIAL_PO,), fail_if_missing=True):
     """
     For the given locale, merge the `sources` files to become the `target`
     file.  Note that the target file might also be one of the sources.

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -57,14 +57,14 @@ class TestExtract(I18nToolTestCase):
         """
         Returns the name of the generated django file
         """
-        return 'django-partial.po'
+        return extract.DJANGO_PARTIAL_PO
 
     @property
     def djangojs_po(self):
         """
         Returns the name of the generated djangojs file
         """
-        return 'djangojs-partial.po'
+        return extract.DJANGOJS_PARTIAL_PO
 
     def get_files(self):
         """
@@ -72,7 +72,7 @@ class TestExtract(I18nToolTestCase):
         Returns the fully expanded filenames for all extracted files
         Fails assertion if one of the files doesn't exist.
         """
-        generated_files = ('mako.po', self.django_po, self.djangojs_po,)
+        generated_files = (extract.MAKO_PO, self.django_po, self.djangojs_po,)
 
         for filename in generated_files:
             path = Path.joinpath(self.configuration.source_messages_dir, filename)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -13,6 +13,7 @@ from polib import pofile
 from pytz import UTC
 
 from i18n import config, generate
+from i18n.extract import DJANGO_PARTIAL_PO, DJANGO_PO
 
 from . import I18nToolTestCase, MOCK_APPLICATION_DIR, MOCK_DJANGO_APP_DIR
 
@@ -56,7 +57,7 @@ class TestGenerate(I18nToolTestCase):
         generate.merge(
             test_configuration,
             test_configuration.source_locale,
-            sources=("django-partial.po", "nonexistingfile.po"),
+            sources=(DJANGO_PARTIAL_PO, "nonexistingfile.po"),
             target=filename,
             fail_if_missing=False,
         )
@@ -73,7 +74,7 @@ class TestGenerate(I18nToolTestCase):
             generate.merge(
                 test_configuration,
                 test_configuration.source_locale,
-                sources=("django-partial.po", "nonexistingfile.po"),
+                sources=(DJANGO_PARTIAL_PO, "nonexistingfile.po"),
                 target=filename,
                 fail_if_missing=True,
             )
@@ -127,7 +128,7 @@ class TestGenerate(I18nToolTestCase):
 
     @patch('i18n.generate.LOG')
     def test_resolve_merge_conflicts(self, mock_log):
-        django_po_path = Path.joinpath(self.configuration.get_messages_dir('mock'), 'django.po')
+        django_po_path = Path.joinpath(self.configuration.get_messages_dir('mock'), DJANGO_PO)
         # File ought to have been generated in test_main
         # if not Path.exists(django_po_path):
         generate.main(verbose=0, strict=False, root_dir=MOCK_APPLICATION_DIR)

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -6,6 +6,7 @@ import shutil
 from path import Path
 import polib
 
+from i18n.extract import DJANGO_PO
 from i18n.segment import segment_pofile
 
 from . import I18nToolTestCase
@@ -32,7 +33,7 @@ class SegmentTest(I18nToolTestCase):
         self.assertEqual(po1, po2)
 
     def test_sample_data(self):
-        work_file = WORK / "django.po"
+        work_file = WORK / DJANGO_PO
         shutil.copyfile(TEST_DATA / "django_before.po", work_file)
         original_pofile = polib.pofile(work_file)
 
@@ -46,7 +47,7 @@ class SegmentTest(I18nToolTestCase):
             }
         )
 
-        self.assertEqual(written, {WORK / "django.po", WORK / "studio.po"})
+        self.assertEqual(written, {WORK / DJANGO_PO, WORK / "studio.po"})
 
         pofiles = [polib.pofile(f) for f in written]
         after_entries = sum(len(pofile) for pofile in pofiles)
@@ -56,5 +57,5 @@ class SegmentTest(I18nToolTestCase):
         after_ids = {m.msgid for pofile in pofiles for m in pofile}
         self.assertEqual(original_ids, after_ids)
 
-        self.assert_pofile_same(WORK / "django.po", TEST_DATA / "django_after.po")
+        self.assert_pofile_same(WORK / DJANGO_PO, TEST_DATA / "django_after.po")
         self.assert_pofile_same(WORK / "studio.po", TEST_DATA / "studio.po")


### PR DESCRIPTION
By mistake, we use `django_partial` and `djangojs_partial` naming instead of `django-partial.po` and `djangojs-partial.po`

This is considered a patch to https://github.com/openedx/i18n-tools/pull/129

Before the fix, no cleaning was done: for example https://github.com/Zeit-Labs/openedx-translations/pull/67/files#r1312206111
After the fix, cleaning is working on the generated files: https://github.com/Zeit-Labs/openedx-translations/pull/72/files#r1312299530
