### PR TITLE
feat: restore PO-Revision-Date but with fixed value

### DIFF
--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 
 
 class Runner:

--- a/i18n/extract.py
+++ b/i18n/extract.py
@@ -316,9 +316,9 @@ def fix_metadata(pofile):
         'Last-Translator': '',
         'Language-Team': 'openedx-translation <openedx-translation@googlegroups.com>',
         'Plural-Forms': 'nplurals=2; plural=(n != 1);',
+        'POT-Creation-Date': '2023-06-13 08:00+0000',
+        'PO-Revision-Date': '2023-06-13 09:00+0000',
     }
-    pofile.metadata.pop('POT-Creation-Date', None)
-    pofile.metadata.pop('PO-Revision-Date', None)
     pofile.metadata.update(fixes)
 
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -47,12 +47,14 @@ def perform_extract_with_options():
     return decorator
 
 
-@ddt.ddt
-class TestExtract(I18nToolTestCase):
+class ExtractInitTestMixin(I18nToolTestCase):
     """
-    Tests functionality of i18n/extract.py
+    Mixin for that initializes the test environment for testing extract functionality
     """
     def setUp(self):
+        """
+        Initialize the test environment
+        """
         super().setUp()
 
         # Subtract 1 second to help comparisons with file-modify time succeed,
@@ -73,6 +75,12 @@ class TestExtract(I18nToolTestCase):
         self.ddt_flag_merge_po_files = None
         self.ddt_flag_no_segment = None
 
+
+@ddt.ddt
+class TestExtract(ExtractInitTestMixin):
+    """
+    Tests functionality of i18n/extract.py
+    """
     @property
     def django_po(self):
         """
@@ -168,14 +176,15 @@ class TestExtract(I18nToolTestCase):
             self.assertEquals(expected, value)
 
     @perform_extract_with_options()
-    def test_metadata_no_create_date(self):
+    def test_metadata_fixed_creation_and_revision_dates(self):
         """
-        Verify `POT-Creation-Date` metadata has been removed
+        Verify `POT-Creation-Date` and `PO-Revision-Date` metadata are always set to a fixed date-time
         """
         for path in self.get_files():
             po = polib.pofile(path)
             metadata = po.metadata
-            self.assertIsNone(metadata.get('POT-Creation-Date'))
+            self.assertEqual(metadata.get('POT-Creation-Date'), '2023-06-13 08:00+0000')
+            self.assertEqual(metadata.get('PO-Revision-Date'), '2023-06-13 09:00+0000')
 
     @perform_extract_with_options()
     def test_merge_po_files(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,49 @@
+"""
+Tests for integration between different parts of the i18n-tools packages
+"""
+import os
+from datetime import datetime, timedelta
+from functools import wraps
+import itertools
+
+import ddt
+import sys
+import io
+from i18n import validate, config
+from path import Path
+
+from . import I18nToolTestCase, MOCK_DJANGO_APP_DIR
+
+from . import test_extract
+
+
+@ddt.ddt
+class TestIntegration(test_extract.ExtractInitTestMixin):
+    """
+    Tests for integration between different parts of the i18n-tools packages
+    """
+    def verify_via_validate_command(self, check_all):
+        """
+        Helper to verify that extract and validate work together
+        """
+        return validate.main(
+            verbosity=0,
+            config=self.configuration._filename,
+            root_dir=MOCK_DJANGO_APP_DIR,
+            check_all=check_all,
+        )
+
+    @test_extract.perform_extract_with_options()
+    def test_extract_then_validate(self):
+        """
+        Test that extract and validate work together
+        """
+        for check_all in [True, False]:
+            # Extract is called by the `@test_extract.perform_extract_with_options()` helper.
+            result = self.verify_via_validate_command(check_all)
+
+            assert result == 0, (
+                'Validation after extract failed, see (Captured log call) for details\n'
+                f'extract options: merge_po_files={self.ddt_flag_merge_po_files}, no_segment={self.ddt_flag_no_segment}\n'
+                f'validate options: check_all={check_all}'
+            )


### PR DESCRIPTION
External packages are forcing validation on `PO-Revision-Date`. Therefore, we are restoring both `POT-Creation-Date` and `PO-Revision-Date` but setting a fixed value for them to avoid having a lot of false (git diff) lines. Note: (2023-06-13 is Palm release date)

This is a fix for a defect reported in `credentials` repository: https://github.com/openedx/i18n-tools/issues/131

Reverts part of the work done here https://github.com/openedx/i18n-tools/pull/129

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
