### PR TITLE
feanil/fix readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
 
     - name: Upload coverage to CodeCov
       if: matrix.python-version == '3.8' && matrix.toxenv == 'django42'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -25,7 +25,7 @@ jobs:
         run: python setup.py sdist bdist_wheel
 
       - name: Publish to PyPi
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_UPLOAD_TOKEN }}

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '1.4.0'
+__version__ = '1.5.0'
 
 
 class Runner:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import re
+import pathlib
 
 from setuptools import setup
 
@@ -42,11 +43,17 @@ def get_version(*file_paths):
 
 VERSION = get_version("i18n", "__init__.py")
 
+here = pathlib.Path(__file__).parent.resolve()
+
+# Get the long description from the README file
+long_description = (here / "README.rst").read_text(encoding="utf-8")
 
 setup(
     name='edx-i18n-tools',
     version=VERSION,
     description='edX Internationalization Tools',
+    long_description=long_description,
+    long_description_content_type='text/x-rst',
     author='edX',
     author_email='oscm@edx.org',
     url='https://github.com/openedx/i18n-tools',


### PR DESCRIPTION
Publish a long_description so releases work again.

It looks like this wasn't required before but now the publish fails without it.

- **build: Add a long description.**
- **build: The publish action now does releases so we switch to v1**

This PR also had to update codecov to the latest version and behind the scenes a github actions secret was added with the CODECOV_TOKEN so that codecov uploads will work here.
