### PR TITLE
fix: unpin lxml constraint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ $(COMMON_CONSTRAINTS_TXT):
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: piptools $(COMMON_CONSTRAINTS_TXT)## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
- 	pip install -qr requirements/pip_tools.txt
+	pip install -qr requirements/pip_tools.txt
 	pip-compile --allow-unsafe --upgrade --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip_tools.txt requirements/pip_tools.in
 	pip install -qr requirements/pip.txt

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '1.4.0'
+__version__ = '1.6.0'
 
 
 class Runner:

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '1.5.0'
+__version__ = '1.4.0'
 
 
 class Runner:

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,4 +5,4 @@ Django
 polib
 path
 pyYaml
-lxml
+lxml[html_clean]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,17 +14,19 @@ django==4.2.11
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
-lxml==4.9.3
+lxml[html-clean,html_clean]==5.2.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
-path==16.10.0
+    #   lxml-html-clean
+lxml-html-clean==0.1.1
+    # via lxml
+path==16.14.0
     # via -r requirements/base.in
 polib==1.2.0
     # via -r requirements/base.in
 pyyaml==6.0.1
     # via -r requirements/base.in
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via django
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via asgiref

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -36,7 +36,7 @@ click-log==0.4.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-code-annotations==1.7.0
+code-annotations==1.8.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -44,7 +44,7 @@ colorama==0.4.6
     # via
     #   -r requirements/tox.txt
     #   tox
-coverage[toml]==7.4.4
+coverage[toml]==7.5.0
     # via
     #   -r requirements/ci.in
     #   -r requirements/test.txt
@@ -65,11 +65,11 @@ django==4.2.11
     #   -r requirements/test.txt
 edx-lint==5.3.6
     # via -r requirements/test.txt
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   -r requirements/test.txt
     #   pytest
-filelock==3.13.3
+filelock==3.13.4
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -86,10 +86,12 @@ jinja2==3.1.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
-lxml==4.9.3
+lxml[html-clean]==5.2.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
+    #   lxml-html-clean
+lxml-html-clean==0.1.1
+    # via -r requirements/test.txt
 markupsafe==2.1.5
     # via
     #   -r requirements/test.txt
@@ -109,20 +111,20 @@ packaging==24.0
     #   pyproject-api
     #   pytest
     #   tox
-path==16.10.0
+path==16.14.0
     # via -r requirements/test.txt
 pbr==6.0.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   -r requirements/test.txt
     #   -r requirements/tox.txt
     #   pylint
     #   tox
     #   virtualenv
-pluggy==1.4.0
+pluggy==1.5.0
     # via
     #   -r requirements/test.txt
     #   -r requirements/tox.txt
@@ -177,7 +179,7 @@ six==1.16.0
     #   -r requirements/test.txt
     #   edx-lint
     #   mock
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via
     #   -r requirements/test.txt
     #   django
@@ -204,13 +206,13 @@ tomlkit==0.12.4
     #   pylint
 tox==4.14.2
     # via -r requirements/tox.txt
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   -r requirements/test.txt
     #   asgiref
     #   astroid
     #   pylint
-virtualenv==20.25.1
+virtualenv==20.26.0
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -3,11 +3,6 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
-# This is a temporary solution to override the real common_constraints.txt
-# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
-# See BOM-2721 for more details.
-# Below is the copied and edited version of common_constraints
-
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #
@@ -30,6 +25,7 @@ Django<5.0
 elasticsearch<7.14.0
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0
 
 # opentelemetry requires version 6.x at the moment:
 # https://github.com/open-telemetry/opentelemetry-python/issues/3570

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,6 +16,3 @@ mock<4.0.0
 
 # temporary constraint
 backports.zoneinfo;python_version<"3.9"
-
-# greater version has issues.
-lxml==4.9.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -42,7 +42,7 @@ click-log==0.4.0
     # via
     #   -r requirements/ci.txt
     #   edx-lint
-code-annotations==1.7.0
+code-annotations==1.8.0
     # via
     #   -r requirements/ci.txt
     #   edx-lint
@@ -50,7 +50,7 @@ colorama==0.4.6
     # via
     #   -r requirements/ci.txt
     #   tox
-coverage[toml]==7.4.4
+coverage[toml]==7.5.0
     # via
     #   -r requirements/ci.txt
     #   pytest-cov
@@ -70,11 +70,11 @@ django==4.2.11
     #   -r requirements/ci.txt
 edx-lint==5.3.6
     # via -r requirements/ci.txt
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   -r requirements/ci.txt
     #   pytest
-filelock==3.13.3
+filelock==3.13.4
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -96,10 +96,12 @@ jinja2==3.1.3
     # via
     #   -r requirements/ci.txt
     #   code-annotations
-lxml==4.9.3
+lxml[html-clean]==5.2.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/ci.txt
+    #   lxml-html-clean
+lxml-html-clean==0.1.1
+    # via -r requirements/ci.txt
 markupsafe==2.1.5
     # via
     #   -r requirements/ci.txt
@@ -120,7 +122,7 @@ packaging==24.0
     #   pyproject-api
     #   pytest
     #   tox
-path==16.10.0
+path==16.14.0
     # via -r requirements/ci.txt
 pbr==6.0.0
     # via
@@ -128,13 +130,13 @@ pbr==6.0.0
     #   stevedore
 pip-tools==7.4.1
     # via -r requirements/pip_tools.txt
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   -r requirements/ci.txt
     #   pylint
     #   tox
     #   virtualenv
-pluggy==1.4.0
+pluggy==1.5.0
     # via
     #   -r requirements/ci.txt
     #   pytest
@@ -193,7 +195,7 @@ six==1.16.0
     #   -r requirements/ci.txt
     #   edx-lint
     #   mock
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via
     #   -r requirements/ci.txt
     #   django
@@ -223,13 +225,13 @@ tomlkit==0.12.4
     #   pylint
 tox==4.14.2
     # via -r requirements/ci.txt
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   -r requirements/ci.txt
     #   asgiref
     #   astroid
     #   pylint
-virtualenv==20.25.1
+virtualenv==20.26.0
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.43.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.0
     # via -r requirements/pip.in
-setuptools==69.2.0
+setuptools==69.5.1
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -24,9 +24,9 @@ click==8.1.7
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==1.7.0
+code-annotations==1.8.0
     # via edx-lint
-coverage[toml]==7.4.4
+coverage[toml]==7.5.0
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -39,7 +39,7 @@ dill==0.3.8
     #   -r requirements/base.txt
 edx-lint==5.3.6
     # via -r requirements/test.in
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via pytest
 iniconfig==2.0.0
     # via pytest
@@ -47,10 +47,14 @@ isort==5.13.2
     # via pylint
 jinja2==3.1.3
     # via code-annotations
-lxml==4.9.3
+lxml[html-clean]==5.2.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
+    #   lxml-html-clean
+lxml-html-clean==0.1.1
+    # via
+    #   -r requirements/base.txt
+    #   lxml
 markupsafe==2.1.5
     # via jinja2
 mccabe==0.7.0
@@ -61,13 +65,13 @@ mock==3.0.5
     #   -r requirements/test.in
 packaging==24.0
     # via pytest
-path==16.10.0
+path==16.14.0
     # via -r requirements/base.txt
 pbr==6.0.0
     # via stevedore
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via pylint
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 polib==1.2.0
     # via -r requirements/base.txt
@@ -103,7 +107,7 @@ six==1.16.0
     # via
     #   edx-lint
     #   mock
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via
     #   -r requirements/base.txt
     #   django
@@ -118,7 +122,7 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.12.4
     # via pylint
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   -r requirements/base.txt
     #   asgiref

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -12,7 +12,7 @@ colorama==0.4.6
     # via tox
 distlib==0.3.8
     # via virtualenv
-filelock==3.13.3
+filelock==3.13.4
     # via
     #   tox
     #   virtualenv
@@ -20,11 +20,11 @@ packaging==24.0
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   tox
     #   virtualenv
-pluggy==1.4.0
+pluggy==1.5.0
     # via tox
 pyproject-api==1.6.1
     # via tox
@@ -34,5 +34,5 @@ tomli==2.0.1
     #   tox
 tox==4.14.2
     # via -r requirements/tox.in
-virtualenv==20.25.1
+virtualenv==20.26.0
     # via tox

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -62,4 +62,4 @@ class TestConverter(I18nToolTestCase):
         """
         source, expected = data
         result = UpcaseConverter().convert(source)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -19,14 +19,14 @@ class TestDummy(I18nToolTestCase):
         self.converter = dummy.Dummy()
 
     def assertUnicodeEquals(self, str1, str2):
-        """Just like assertEquals, but doesn't put Unicode into the fail message.
+        """Just like assertEqual, but doesn't put Unicode into the fail message.
 
         Either nose, or rake, or something, deals very badly with unusual
         Unicode characters in the assertions, so we use repr here to keep
         things safe.
 
         """
-        self.assertEquals(
+        self.assertEqual(
             str1, str2,
             "Mismatch: %r != %r" % (str1, str2),
         )

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -173,7 +173,7 @@ class TestExtract(ExtractInitTestMixin):
             metadata = po.metadata
             value = metadata['Report-Msgid-Bugs-To']
             expected = 'openedx-translation@googlegroups.com'
-            self.assertEquals(expected, value)
+            self.assertEqual(expected, value)
 
     @perform_extract_with_options()
     def test_metadata_fixed_creation_and_revision_dates(self):

--- a/tests/test_transifex.py
+++ b/tests/test_transifex.py
@@ -104,4 +104,4 @@ class TestTransifex(I18nToolTestCase):
             transifex.clean_locale(self.configuration, 'fr')
             self.assertEqual(12, patched.call_count)
             for callarg in patched.call_args_list:
-                self.assertRegexpMatches(callarg[0][1].name, r'.*\.po')
+                self.assertRegex(callarg[0][1].name, r'.*\.po')


### PR DESCRIPTION
- Related to https://github.com/openedx/xblock-sdk/issues/347

Fixes Error

```
E   ImportError: lxml.html.clean module is now a separate project lxml_html_clean.
E   Install lxml[html_clean] or lxml_html_clean directly.
```

```
E       AttributeError: 'TestConverter' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?
```

```
E       AttributeError: 'TestTransifex' object has no attribute 'assertRegexpMatches'
```
