### PR TITLE
build: Bump the version so we can release some setup.py updates.

### DIFF
--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -7,7 +7,7 @@ import sys
 
 from . import config
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"
 
 
 class Runner:


### PR DESCRIPTION
We updated setup.py based on the latest version in the cookiecutter and
that will impact how the package announces its requirements to include
optional dependencies more correctly.
