### PR TITLE
Feat: Add django52 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         python-version:
         - '3.11'
         - '3.12'
-        toxenv: [quality, django42]
+        toxenv: [quality, django42, django52]
     steps:
     - uses: actions/checkout@v2
 

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -7,7 +7,7 @@ import sys
 
 from . import config
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"
 
 
 class Runner:

--- a/setup.py
+++ b/setup.py
@@ -150,5 +150,6 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Framework :: Django",
         "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.2",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311, 312}-django{42}, quality
+envlist = py{311, 312}-django{42,52}, quality
 
 [pytest]
 addopts = --cov=tests --cov-report term --cov-config=.coveragerc -p no:randomly
@@ -8,6 +8,7 @@ testpaths = tests
 [testenv]
 deps = 
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     -r requirements/test.txt
 commands = pytest {posargs}
 


### PR DESCRIPTION
Resolves #194 

## Add Django 5.2 Support
This PR updates the codebase to be compatible with Django 5.2 while maintaining compatibility with Django 4.2.

### Changes Made:
- Update ci and tox files
- Ran django-upgrade to apply necessary syntax updates for Django 5.2.
- Run tests using tox command and resolved the warning
- Ensured all modifications remain backward-compatible with Django 4.2.

### django-upgrade usage:
`git ls-files -z -- '*.py' | xargs -0r django-upgrade --target-version 5.2`